### PR TITLE
fix: `abbrev` renamed to `abbr`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 
 export interface TimeZoneInfo {
   name: string;
-  abbrev: string;
+  abbr: string;
 }
 
 export interface DisplayFormat {


### PR DESCRIPTION
Noticed in using `1.3.1` that the daylight and standard objects have the key defined as `abbr`, not `abbrev` as it was in the `spacetime-informal` days.